### PR TITLE
Create and push tag step raise error. Artifact release already exists…

### DIFF
--- a/.github/workflows/library_master.yml
+++ b/.github/workflows/library_master.yml
@@ -84,12 +84,6 @@ jobs:
         with:
           arguments: ${{ inputs.artifacts_publish_command }} -PreleaseVersion=${{ steps.version.outputs.version }} -PmavenUser=aws -PmavenPassword=${{ steps.vars.outputs.codeartifact_auth_token }}
 
-      - name: "Publish: Create and push tag"
-        if: ${{ success() && inputs.build_command != 0 && inputs.artifacts_publish_command != 0 }}
-        run: |
-          git tag ${{ steps.version.outputs.version_tag }}
-          git push origin ${{ steps.version.outputs.version_tag }}
-
       - name: "Notify: Slack"
         id: slack
         if: ${{ failure() && inputs.slack_channel_id != 0 }}


### PR DESCRIPTION
…. Because on step Publish artifacts it's create new tag and publish it.