### PR TITLE
AT 389 action manual release

### DIFF
--- a/.github/workflows/application_master.yml
+++ b/.github/workflows/application_master.yml
@@ -128,7 +128,7 @@ jobs:
             JVM_MIN=-Xms1024m
             JVM_MAX=-Xmx2048m
           push: true
-          tags: ${{ secrets.aws_env_account_id }}.dkr.ecr.eu-central-1.amazonaws.com/${{ inputs.service_name }}:${{ steps.version.outputs.version_tag }},${{ secrets.aws_env_account_id }}.dkr.ecr.eu-central-1.amazonaws.com/${{ inputs.service_name }}:latest
+          tags: ${{ secrets.aws_env_account_id }}.dkr.ecr.eu-central-1.amazonaws.com/${{ inputs.service_name }}:${{ steps.version.outputs.version_tag }}
 
       - name: "Publish: Create and push tag"
         if: ${{ success() && inputs.build_command != 0 }}

--- a/.github/workflows/application_tag.yml
+++ b/.github/workflows/application_tag.yml
@@ -57,8 +57,7 @@ jobs:
       - name: "Get latest tag if input is empty"
         if: ${{ inputs.deploy_tag != 0 }}
         run: |
-          latest_tag=$(git describe --abbrev=0)
-          echo "DEPLOY_TAG=${{ latest_tag }}" >> $GITHUB_ENV
+          echo "DEPLOY_TAG=$(git describe --abbrev=0)" >> $GITHUB_ENV
 
       - name: "Setup: AWS Credentials"
         uses: aws-actions/configure-aws-credentials@v1

--- a/.github/workflows/application_tag.yml
+++ b/.github/workflows/application_tag.yml
@@ -54,7 +54,7 @@ jobs:
         id: check_tags
         shell: bash
         run: |
-          if [ "${{ inputs.deploy_tag != 0 }}" == "" ]; then
+          if [ "${{ inputs.deploy_tag }}" == "" ]; then
              echo ::set-output name=tag::$(git describe --abbrev=0)"
            else
              echo ::set-output name=tag::${{inputs.deploy_tag}}"

--- a/.github/workflows/application_tag.yml
+++ b/.github/workflows/application_tag.yml
@@ -51,7 +51,6 @@ jobs:
           fetch-depth: 0
 
       - name: "Set tag to deploy"
-        description: "tag is obtained from input or latest one by default"
         id: check_tags
         shell: bash
         run: |

--- a/.github/workflows/application_tag.yml
+++ b/.github/workflows/application_tag.yml
@@ -96,11 +96,11 @@ jobs:
         run: |
           gh release create ${{ env.DEPLOY_TAG }} -t release-${{ steps.bump_gh_release_version.outputs.next-version }} --generate-notes
           release_json=$(gh api repos/meawallet/${{ github.event.repository.name }}/releases/tags/${{ env.DEPLOY_TAG }})
-          release_title=$(jq '.name' <<< "$release_json")
+          release_title=$(jq -r '.name' <<< "$release_json")
           echo "::set-output name=release_title::$release_title"
-          release_body=$(jq '.body' <<< "$release_json")
+          release_body=$(gh api repos/meawallet/${{ github.event.repository.name }}/releases/tags/${{ env.DEPLOY_TAG }} | jq -r '.body')
           echo "::set-output name=release_body::$release_body"
-          release_url=$(jq '.html_url' <<< "$release_json")
+          release_url=$(jq -r '.html_url' <<< "$release_json")
           echo "::set-output name=release_url::$release_url"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -115,21 +115,53 @@ jobs:
           channel-id: acquiring_releases
           payload: |
             {
-              "text": ${{ steps.gh_new_release.outputs.release_title }},
-              "blocks": [
+              "text": "${{ steps.gh_new_release.outputs.release_title }}",
+              "blocks":
+              [
                 {
                   "type": "header",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": <${{ steps.gh_new_release.outputs.release_url }}|${{ steps.gh_new_release.outputs.release_title }}>
-                  }
+                  "text":
+                    {
+                      "type": "mrkdwn",
+                      "text": "${{ steps.gh_new_release.outputs.release_title }}"
+                    }
                 },
                 {
                   "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": ${{ steps.gh_new_release.outputs.release_body }}
-                  }
+                  "text":
+                    {
+                      "type": "mrkdwn",
+                      "text": "*<${{ steps.gh_new_release.outputs.release_url }}|Check on github>*"
+                    }
+                },
+                {
+                  "type": "section",
+                  "text":
+                    {
+                      "type": "mrkdwn",
+                      "text": "${{ steps.gh_new_release.outputs.release_body }}"
+                    }
+                },
+                {
+                  "type": "section",
+                  "text":
+                    {
+                      "type": "mrkdwn",
+                      "text": "Check full changes."
+                    },
+                  "accessory":
+                    {
+                      "type": "button",
+                      "text":
+                        {
+                          "type": "plain_text",
+                          "text": "Check on Github",
+                          "emoji": true
+                        },
+                      "value": "click_me_123",
+                      "url": "${{ steps.gh_new_release.outputs.release_url }}",
+                      "action_id": "button-action"
+                    }
                 }
               ]
             }

--- a/.github/workflows/application_tag.yml
+++ b/.github/workflows/application_tag.yml
@@ -61,7 +61,7 @@ jobs:
 
       - name: "Get latest github release"
         run: |
-          echo "LATEST_GH_RELEASE=$(gh release list | head -1 |  awk '{print $1}')" >> $GITHUB_ENV
+          echo "LATEST_GH_RELEASE=$(gh release list | head -1 |  awk '{print substr($1,9)}')" >> $GITHUB_ENV
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -74,7 +74,7 @@ jobs:
 
       - name: "Create new github release version"
         run: |
-          gh release create ${{ steps.bump_gh_release_version.outputs.next-version }} --generate-notes
+          gh release create release-${{ steps.bump_gh_release_version.outputs.next-version }} --generate-notes
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/application_tag.yml
+++ b/.github/workflows/application_tag.yml
@@ -59,16 +59,15 @@ jobs:
         run: |
           echo "DEPLOY_TAG=$(git tag --sort=committerdate | tail -1)" >> $GITHUB_ENV
 
-      - name: "Check if release already exists"
+      - name: "Check if a github release already exists"
         id: find_release
         run: |
-          release_tag_exist=$(gh api --silent repos/meawallet/${{ github.event.repository.name }}/releases/tags/${{env.DEPLOY_TAG }} 2>&1 >/dev/null)
-          echo "::set-output name=release_tag_exist::$release_tag_exist"
+          gh api --silent repos/meawallet/${{ github.event.repository.name }}/releases/tags/${{env.DEPLOY_TAG }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: "Get latest github release"
-        if: ${{ steps.find_release.outputs.release_tag_exist != 0 }}
+        if: failure() && ${{ steps.find_release.outputs.release_tag_exist != 0 }}
         run: |
           echo "LATEST_GH_RELEASE=$(gh api repos/meawallet/${{ github.event.repository.name }}/releases/latest --jq '.name' |  awk '{print substr($1,9)}')" >> $GITHUB_ENV
         env:
@@ -76,14 +75,14 @@ jobs:
 
       - name: "Bump github release version"
         id: bump_gh_release_version
-        if: ${{ steps.find_release.outputs.release_tag_exist != 0 }}
+        if: failure()
         uses: christian-draeger/increment-semantic-version@1.0.2
         with:
           current-version: ${{ env.LATEST_GH_RELEASE }}
           version-fragment: 'bug'
 
       - name: "Create new github release version"
-        if: ${{ steps.find_release.outputs.release_tag_exist != 0 }}
+        if: failure()
         run: |
           gh release create release-${{ steps.bump_gh_release_version.outputs.next-version }} --generate-notes
         env:

--- a/.github/workflows/application_tag.yml
+++ b/.github/workflows/application_tag.yml
@@ -50,14 +50,16 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: "Set tag to deploy from input"
+      - name: "Set tag to deploy"
+        description: "tag is obtained from input or latest one by default"
+        id: check_tags
+        shell: bash
         run: |
-          echo "DEPLOY_TAG=${{ inputs.deploy_tag }}" >> $GITHUB_ENV
-
-      - name: "Get latest tag if input is empty"
-        if: ${{ inputs.deploy_tag != 0 }}
-        run: |
-          echo "DEPLOY_TAG=$(git describe --abbrev=0)" >> $GITHUB_ENV
+          if [ "${{ inputs.deploy_tag != 0 }}" == "" ]; then
+             echo ::set-output name=tag::$(git describe --abbrev=0)"
+           else
+             echo ::set-output name=tag::${{inputs.deploy_tag}}"
+           fi
 
       - name: "Setup: AWS Credentials"
         uses: aws-actions/configure-aws-credentials@v1
@@ -82,7 +84,7 @@ jobs:
         with:
           token: ${{ secrets.cd_token }}
           event-type: dev-release
-          client-payload: '{"service_name": "${{ inputs.app_name }}", "image_version": "${{ env.DEPLOY_TAG }}"}'
+          client-payload: '{"service_name": "${{ inputs.app_name }}", "image_version": "${{ steps.check_tags.outputs.tag }}"}'
           repository: ${{ inputs.deploy_repo }}
 
       - name: "Notify: Slack"

--- a/.github/workflows/application_tag.yml
+++ b/.github/workflows/application_tag.yml
@@ -98,9 +98,10 @@ jobs:
           release_title=$(gh api repos/meawallet/${{ github.event.repository.name }}/releases/latest --jq '.name + " " + .html_url')
           echo "::set-output name=release_title::$release_title"
           RELEASE_BODY=$(gh api repos/meawallet/${{ github.event.repository.name }}/releases/latest --jq '.body')
-          echo "RELEASE_BODY<<EOF" >> $GITHUB_ENV
-          echo "$RELEASE_BODY" >> $GITHUB_ENV
-          echo "EOF" >> $GITHUB_ENV
+          RELEASE_BODY="${RELEASE_BODY//'%'/'%25'}"
+          RELEASE_BODY="${RELEASE_BODY//$'\n'/'%0A'}"
+          RELEASE_BODY="${RELEASE_BODY//$'\r'/'%0D'}"
+          echo "::set-output name=release_body::$RELEASE_BODY"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -120,7 +121,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "${{ env.RELEASE_BODY }}"
+                    "text": "${{ steps.gh_new_release.outputs.release_body }}"
                   }
                 }
               ]

--- a/.github/workflows/application_tag.yml
+++ b/.github/workflows/application_tag.yml
@@ -179,4 +179,4 @@ jobs:
         uses: slackapi/slack-github-action@v1.19.0
         with:
           channel-id: ${{ inputs.slack_channel_id }}
-          slack-message: Pipeline failed for ${{ github.event.repository.name }} and ${{ github.workflow }} workflow with error ${{ steps.vars.outputs.run_url }}
+          slack-message: Pipeline failed *${{ github.workflow }}* ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/application_tag.yml
+++ b/.github/workflows/application_tag.yml
@@ -62,12 +62,21 @@ jobs:
       - name: "Check if a github release already exists"
         id: find_release
         run: |
-          gh api --silent repos/meawallet/${{ github.event.repository.name }}/releases/tags/${{env.DEPLOY_TAG }}
+          get_release_tag_command=$(curl -s -o /dev/null -I -w "%{http_code}" -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" "https://api.github.com/repos/meawallet/meapay-service-attestation/releases/tags/${{ env.DEPLOY_TAG }}")
+          if [ $get_release_tag_command -eq 200 ] ; then
+            echo "tag release already exists"
+            echo "::set-output name=release_tag_exist::0"
+          elif [ $get_release_tag_command -eq 404 ] ; then
+            echo "tag release does not exists"
+            echo "::set-output name=release_tag_exist::1"
+          else 
+            exit 1
+          fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: "Get latest github release"
-        if: failure() && ${{ steps.find_release.outputs.release_tag_exist != 0 }}
+        if: ${{ steps.find_release.outputs.release_tag_exist != 0 }}
         run: |
           echo "LATEST_GH_RELEASE=$(gh api repos/meawallet/${{ github.event.repository.name }}/releases/latest --jq '.name' |  awk '{print substr($1,9)}')" >> $GITHUB_ENV
         env:
@@ -75,14 +84,14 @@ jobs:
 
       - name: "Bump github release version"
         id: bump_gh_release_version
-        if: failure()
+        if: ${{ steps.find_release.outputs.release_tag_exist != 0 }}
         uses: christian-draeger/increment-semantic-version@1.0.2
         with:
           current-version: ${{ env.LATEST_GH_RELEASE }}
           version-fragment: 'bug'
 
       - name: "Create new github release version"
-        if: failure()
+        if: ${{ steps.find_release.outputs.release_tag_exist != 0 }}
         run: |
           gh release create release-${{ steps.bump_gh_release_version.outputs.next-version }} --generate-notes
         env:

--- a/.github/workflows/application_tag.yml
+++ b/.github/workflows/application_tag.yml
@@ -59,20 +59,31 @@ jobs:
         run: |
           echo "DEPLOY_TAG=$(git tag --sort=committerdate | tail -1)" >> $GITHUB_ENV
 
-      - name: "Get latest github release"
+      - name: "Check if release already exists"
+        id: find_release
         run: |
-          echo "LATEST_GH_RELEASE=$(gh release list | head -1 |  awk '{print substr($1,9)}')" >> $GITHUB_ENV
+          release_tag_exist=$(gh api --silent repos/meawallet/${{ github.event.repository.name }}/releases/tags/${{env.DEPLOY_TAG }} 2>&1 >/dev/null)
+          echo "::set-output name=release_tag_exist::$release_tag_exist"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: "Get latest github release"
+        if: ${{ steps.find_release.outputs.release_tag_exist != 0 }}
+        run: |
+          echo "LATEST_GH_RELEASE=$(gh api repos/meawallet/${{ github.event.repository.name }}/releases/latest --jq '.name' |  awk '{print substr($1,9)}')" >> $GITHUB_ENV
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: "Bump github release version"
         id: bump_gh_release_version
+        if: ${{ steps.find_release.outputs.release_tag_exist != 0 }}
         uses: christian-draeger/increment-semantic-version@1.0.2
         with:
-          current-version: '0.1.27'
+          current-version: ${{ env.LATEST_GH_RELEASE }}
           version-fragment: 'bug'
 
       - name: "Create new github release version"
+        if: ${{ steps.find_release.outputs.release_tag_exist != 0 }}
         run: |
           gh release create release-${{ steps.bump_gh_release_version.outputs.next-version }} --generate-notes
         env:

--- a/.github/workflows/application_tag.yml
+++ b/.github/workflows/application_tag.yml
@@ -59,6 +59,21 @@ jobs:
         run: |
           echo "DEPLOY_TAG=$(git tag --sort=committerdate | tail -1)" >> $GITHUB_ENV
 
+      - name: "Get latest github release"
+        run: |
+          echo "LATEST_GH_RELEASE=$(gh release list | head -1 |  awk '{print $1}')" >> $GITHUB_ENV
+
+      - name: "Bump github release version"
+        id: bump_gh_release_version
+        uses: christian-draeger/increment-semantic-version@1.0.2
+        with:
+          current-version: ${{ env.LATEST_GH_RELEASE }}'
+          version-fragment: 'bug'
+
+      - name: "Create new github release version"
+        run: |
+          gh release create ${{ steps.bump_gh_release_version.outputs.next-version }} --generate-notes
+
       - name: "Setup: AWS Credentials"
         uses: aws-actions/configure-aws-credentials@v1
         with:

--- a/.github/workflows/application_tag.yml
+++ b/.github/workflows/application_tag.yml
@@ -74,12 +74,12 @@ jobs:
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v1
 
-      - name: "Deploy: Dispatch deployment to the development"
+      - name: "Deploy: Dispatch deployment to tst environment"
         if: ${{ success() && inputs.service_name != 0 && inputs.deploy_repo != 0 }}
         uses: peter-evans/repository-dispatch@v2
         with:
           token: ${{ secrets.cd_token }}
-          event-type: dev-release
+          event-type: tst-release
           client-payload: '{"service_name": "${{ inputs.app_name }}", "image_version": "${{ env.DEPLOY_TAG }}"}'
           repository: ${{ inputs.deploy_repo }}
 

--- a/.github/workflows/application_tag.yml
+++ b/.github/workflows/application_tag.yml
@@ -62,6 +62,8 @@ jobs:
       - name: "Get latest github release"
         run: |
           echo "LATEST_GH_RELEASE=$(gh release list | head -1 |  awk '{print $1}')" >> $GITHUB_ENV
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: "Bump github release version"
         id: bump_gh_release_version
@@ -73,6 +75,8 @@ jobs:
       - name: "Create new github release version"
         run: |
           gh release create ${{ steps.bump_gh_release_version.outputs.next-version }} --generate-notes
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: "Setup: AWS Credentials"
         uses: aws-actions/configure-aws-credentials@v1

--- a/.github/workflows/application_tag.yml
+++ b/.github/workflows/application_tag.yml
@@ -94,14 +94,14 @@ jobs:
         id: gh_new_release
         if: ${{ steps.find_release.outputs.release_tag_exist != 0 }}
         run: |
-          gh release create release-${{ steps.bump_gh_release_version.outputs.next-version }} --generate-notes
-          release_title=$(gh api repos/meawallet/${{ github.event.repository.name }}/releases/latest --jq '.name + " " + .html_url')
+          gh release create ${{ env.DEPLOY_TAG }} -t release-${{ steps.bump_gh_release_version.outputs.next-version }} --generate-notes
+          release_json=$(gh api repos/meawallet/${{ github.event.repository.name }}/releases/tags/${{ env.DEPLOY_TAG }})
+          release_title=$(jq '.name' <<< "$release_json")
           echo "::set-output name=release_title::$release_title"
-          RELEASE_BODY=$(gh api repos/meawallet/${{ github.event.repository.name }}/releases/latest --jq '.body')
-          RELEASE_BODY="${RELEASE_BODY//'%'/'%25'}"
-          RELEASE_BODY="${RELEASE_BODY//$'\n'/'%0A'}"
-          RELEASE_BODY="${RELEASE_BODY//$'\r'/'%0D'}"
-          echo "::set-output name=release_body::$RELEASE_BODY"
+          release_body=$(jq '.body' <<< "$release_json")
+          echo "::set-output name=release_body::$release_body"
+          release_url=$(jq '.html_url' <<< "$release_json")
+          echo "::set-output name=release_url::$release_url"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -115,13 +115,20 @@ jobs:
           channel-id: acquiring_releases
           payload: |
             {
-              "text": "${{ steps.gh_new_release.outputs.release_title }}",
+              "text": ${{ steps.gh_new_release.outputs.release_title }},
               "blocks": [
+                {
+                  "type": "header",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": <${{ steps.gh_new_release.outputs.release_url }}|${{ steps.gh_new_release.outputs.release_title }}>
+                  }
+                },
                 {
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "${{ steps.gh_new_release.outputs.release_body }}"
+                    "text": ${{ steps.gh_new_release.outputs.release_body }}
                   }
                 }
               ]

--- a/.github/workflows/application_tag.yml
+++ b/.github/workflows/application_tag.yml
@@ -50,15 +50,14 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: "Set tag to deploy"
-        id: check_tags
-        shell: bash
+      - name: "Set tag to deploy from input"
         run: |
-          if [ "${{ inputs.deploy_tag }}" == "" ]; then
-             echo ::set-output name=tag::$(git describe --abbrev=0)"
-           else
-             echo ::set-output name=tag::${{inputs.deploy_tag}}"
-           fi
+          echo "DEPLOY_TAG=${{ inputs.deploy_tag }}" >> $GITHUB_ENV
+
+      - name: "Get latest tag if input is empty"
+        if: ${{ inputs.deploy_tag == 0 }}
+        run: |
+          echo "DEPLOY_TAG=$(git describe --abbrev=0)" >> $GITHUB_ENV
 
       - name: "Setup: AWS Credentials"
         uses: aws-actions/configure-aws-credentials@v1
@@ -83,7 +82,7 @@ jobs:
         with:
           token: ${{ secrets.cd_token }}
           event-type: dev-release
-          client-payload: '{"service_name": "${{ inputs.app_name }}", "image_version": "${{ steps.check_tags.outputs.tag }}"}'
+          client-payload: '{"service_name": "${{ inputs.app_name }}", "image_version": "${{ env.DEPLOY_TAG }}"}'
           repository: ${{ inputs.deploy_repo }}
 
       - name: "Notify: Slack"

--- a/.github/workflows/application_tag.yml
+++ b/.github/workflows/application_tag.yml
@@ -1,0 +1,97 @@
+name: reusable-deploy-tag-flow
+
+on:
+  workflow_call:
+    inputs:
+      slack_channel_id:
+        required: false
+        type: string
+      app_name:
+        required: true
+        type: string
+      service_name:
+        required: false
+        type: string
+      deploy_repo:
+        required: false
+        type: string
+      deploy_tag:
+        description: 'Tag to be deployed'
+        required: false
+        type: string
+
+    secrets:
+      aws_ca_domain:
+        description: 'AWS_CA_DOMAIN'
+        required: false
+      aws_ca_owner_id:
+        description: 'AWS_CA_OWNER_ID'
+        required: false
+      aws_role_to_assume:
+        description: 'AWS_ROLE_TO_ASSUME'
+        required: false
+      slack_bot_token:
+        description: 'SLACK_BOT_TOKEN'
+        required: false
+      slack_channel_id:
+        description: 'SLACK_CHANNEL_ID'
+        required: false
+      cd_token:
+        description: 'CD_TOKEN'
+        required: false
+
+jobs:
+  Build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: "Setup: Checkout"
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: "Set tag to deploy from input"
+        run: |
+          echo "DEPLOY_TAG=${{ inputs.deploy_tag }}" >> $GITHUB_ENV
+
+      - name: "Get latest tag if input is empty"
+        if: ${{ inputs.deploy_tag != 0 }}
+        run: |
+          latest_tag=$(git describe --abbrev=0)
+          echo "DEPLOY_TAG=${{ latest_tag }}" >> $GITHUB_ENV
+
+      - name: "Setup: AWS Credentials"
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.aws_role_to_assume }}
+          aws-region: eu-central-1
+
+      - name: "Setup: Initialize variables"
+        id: vars
+        run: |
+          echo "::set-output name=run_url::https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: docker/login-action@v1
+        with:
+          registry: ${{ secrets.aws_role_to_assume }}.dkr.ecr.eu-central-1.amazonaws.com
+
+      - name: "Deploy: Dispatch deployment to the development"
+        if: ${{ success() && inputs.service_name != 0 && inputs.deploy_repo != 0 }}
+        uses: peter-evans/repository-dispatch@v2
+        with:
+          token: ${{ secrets.cd_token }}
+          event-type: dev-release
+          client-payload: '{"service_name": "${{ inputs.app_name }}", "image_version": "${{ env.DEPLOY_TAG }}"}'
+          repository: ${{ inputs.deploy_repo }}
+
+      - name: "Notify: Slack"
+        id: slack
+        if: ${{ failure() && inputs.slack_channel_id != 0 }}
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.slack_bot_token }}
+        uses: slackapi/slack-github-action@v1.18.0
+        with:
+          channel-id: ${{ inputs.slack_channel_id }}
+          slack-message: Pipeline failed ${{ steps.vars.outputs.run_url }}

--- a/.github/workflows/application_tag.yml
+++ b/.github/workflows/application_tag.yml
@@ -98,7 +98,7 @@ jobs:
           release_json=$(gh api repos/meawallet/${{ github.event.repository.name }}/releases/tags/${{ env.DEPLOY_TAG }})
           release_title=$(jq -r '.name' <<< "$release_json")
           echo "::set-output name=release_title::$release_title"
-          release_body=$(gh api repos/meawallet/${{ github.event.repository.name }}/releases/tags/${{ env.DEPLOY_TAG }} | jq -r '.body')
+          release_body=$(jq '.body' <<< "$release_json")
           echo "::set-output name=release_body::$release_body"
           release_url=$(jq -r '.html_url' <<< "$release_json")
           echo "::set-output name=release_url::$release_url"
@@ -131,34 +131,15 @@ jobs:
                   "text":
                     {
                       "type": "mrkdwn",
-                      "text": "*<${{ steps.gh_new_release.outputs.release_url }}|Check on github>*"
-                    }
-                },
-                {
-                  "type": "section",
-                  "text":
-                    {
-                      "type": "mrkdwn",
-                      "text": "${{ steps.gh_new_release.outputs.release_body }}"
-                    }
-                },
-                {
-                  "type": "section",
-                  "text":
-                    {
-                      "type": "mrkdwn",
-                      "text": "Check full changes."
-                    },
-                  "accessory":
-                    {
+                      "text": ${{ steps.gh_new_release.outputs.release_body }}
+                    },                
+                    "accessory": {
                       "type": "button",
-                      "text":
-                        {
-                          "type": "plain_text",
-                          "text": "Check on Github",
-                          "emoji": true
-                        },
-                      "value": "click_me_123",
+                      "text": {
+                        "type": "plain_text",
+                        "text": "Check on Github :github:",
+                        "emoji": true
+                      },
                       "url": "${{ steps.gh_new_release.outputs.release_url }}",
                       "action_id": "button-action"
                     }

--- a/.github/workflows/application_tag.yml
+++ b/.github/workflows/application_tag.yml
@@ -57,7 +57,7 @@ jobs:
       - name: "Get latest tag if input is empty"
         if: ${{ inputs.deploy_tag == 0 }}
         run: |
-          echo "DEPLOY_TAG=$(git describe --abbrev=0)" >> $GITHUB_ENV
+          echo "DEPLOY_TAG=$(git tag --sort=committerdate | tail -1)" >> $GITHUB_ENV
 
       - name: "Setup: AWS Credentials"
         uses: aws-actions/configure-aws-credentials@v1

--- a/.github/workflows/application_tag.yml
+++ b/.github/workflows/application_tag.yml
@@ -91,11 +91,40 @@ jobs:
           version-fragment: 'bug'
 
       - name: "Create new github release version"
+        id: gh_new_release
         if: ${{ steps.find_release.outputs.release_tag_exist != 0 }}
         run: |
           gh release create release-${{ steps.bump_gh_release_version.outputs.next-version }} --generate-notes
+          release_title=$(gh api repos/meawallet/${{ github.event.repository.name }}/releases/latest --jq '.name + " " + .html_url')
+          echo "::set-output name=release_title::$release_title"
+          RELEASE_BODY=$(gh api repos/meawallet/${{ github.event.repository.name }}/releases/latest --jq '.body')
+          echo "RELEASE_BODY<<EOF" >> $GITHUB_ENV
+          echo "$RELEASE_BODY" >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: "Notify: Slack release notes"
+        id: slack-post-release
+        if: ${{ steps.find_release.outputs.release_tag_exist != 0 }}
+        env:
+            SLACK_BOT_TOKEN: ${{ secrets.slack_bot_token }}
+        uses: slackapi/slack-github-action@v1.19.0
+        with:
+          channel-id: acquiring_releases
+          payload: |
+            {
+              "text": "${{ steps.gh_new_release.outputs.release_title }}",
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "${{ env.RELEASE_BODY }}"
+                  }
+                }
+              ]
+            }
 
       - name: "Setup: AWS Credentials"
         uses: aws-actions/configure-aws-credentials@v1
@@ -121,12 +150,12 @@ jobs:
           client-payload: '{"service_name": "${{ inputs.app_name }}", "image_version": "${{ env.DEPLOY_TAG }}"}'
           repository: ${{ inputs.deploy_repo }}
 
-      - name: "Notify: Slack"
+      - name: "Notify: Slack errors"
         id: slack
         if: ${{ failure() && inputs.slack_channel_id != 0 }}
         env:
           SLACK_BOT_TOKEN: ${{ secrets.slack_bot_token }}
-        uses: slackapi/slack-github-action@v1.18.0
+        uses: slackapi/slack-github-action@v1.19.0
         with:
           channel-id: ${{ inputs.slack_channel_id }}
           slack-message: Pipeline failed for ${{ github.event.repository.name }} and ${{ github.workflow }} workflow with error ${{ steps.vars.outputs.run_url }}

--- a/.github/workflows/application_tag.yml
+++ b/.github/workflows/application_tag.yml
@@ -69,7 +69,7 @@ jobs:
         id: bump_gh_release_version
         uses: christian-draeger/increment-semantic-version@1.0.2
         with:
-          current-version: ${{ env.LATEST_GH_RELEASE }}'
+          current-version: '0.1.27'
           version-fragment: 'bug'
 
       - name: "Create new github release version"

--- a/.github/workflows/application_tag.yml
+++ b/.github/workflows/application_tag.yml
@@ -129,4 +129,4 @@ jobs:
         uses: slackapi/slack-github-action@v1.18.0
         with:
           channel-id: ${{ inputs.slack_channel_id }}
-          slack-message: Pipeline failed ${{ steps.vars.outputs.run_url }}
+          slack-message: Pipeline failed for ${{ github.event.repository.name }} and ${{ github.workflow }} workflow with error ${{ steps.vars.outputs.run_url }}

--- a/.github/workflows/application_tag.yml
+++ b/.github/workflows/application_tag.yml
@@ -109,7 +109,7 @@ jobs:
         id: slack-post-release
         if: ${{ steps.find_release.outputs.release_tag_exist != 0 }}
         env:
-            SLACK_BOT_TOKEN: ${{ secrets.slack_bot_token }}
+          SLACK_BOT_TOKEN: ${{ secrets.slack_bot_token }}
         uses: slackapi/slack-github-action@v1.19.0
         with:
           channel-id: acquiring_releases
@@ -122,8 +122,8 @@ jobs:
                   "type": "header",
                   "text":
                     {
-                      "type": "mrkdwn",
-                      "text": "${{ steps.gh_new_release.outputs.release_title }}"
+                      "type": "plain_text",
+                      "text": ":meapay: ${{ steps.gh_new_release.outputs.release_title }}"
                     }
                 },
                 {

--- a/.github/workflows/application_tag.yml
+++ b/.github/workflows/application_tag.yml
@@ -72,9 +72,7 @@ jobs:
 
       - name: Login to Amazon ECR
         id: login-ecr
-        uses: docker/login-action@v1
-        with:
-          registry: ${{ secrets.aws_role_to_assume }}.dkr.ecr.eu-central-1.amazonaws.com
+        uses: aws-actions/amazon-ecr-login@v1
 
       - name: "Deploy: Dispatch deployment to the development"
         if: ${{ success() && inputs.service_name != 0 && inputs.deploy_repo != 0 }}


### PR DESCRIPTION
- AT-389 add tag manual deploy to TST
- AT-389 fix find last tag command
- AT-389 fix find last tag command
- AT-389 fix find last tag command
- AT-389 fix find last tag command
- AT-389 fix find last tag command
- AT-389 fix login ecr
- AT-389 deploy to tst environment
- AT-389 fix last tag from commits
- AT-389 remove latest tag build and push
- AT-389 add github release code
- AT-389 add github token to be able to use cli commands
- AT-389 substring to bump version
- AT-389 test bump version
- AT-389 check if release already exists with the created tag use github api rest endpoints
- AT-389 test failure of action
- AT-389 add find release with curl http codes conditionals
- AT-389 fix slack failure message
- AT-389 add slack message for releases
- AT-389 format slack message in multiple lines
- AT-389 format slack message in multiple lines
- AT-389 format slack message in multiple lines
- AT-389 fix slack error invalid block
- AT-389 final slack release format
